### PR TITLE
[simple] change initial view in ur5e simulation

### DIFF
--- a/assets/universal_robots_ur5e/scene.xml
+++ b/assets/universal_robots_ur5e/scene.xml
@@ -5,7 +5,7 @@
 
   <visual>
     <headlight diffuse="0.6 0.6 0.6" ambient="0.1 0.1 0.1" specular="0 0 0"/>
-    <global azimuth="120" elevation="-20"/>
+    <global azimuth="15" elevation="-20"/>
   </visual>
 
   <asset>


### PR DESCRIPTION
This change make the initial view in simulation similar to human view, so that reduces the teleop complexity.

Before:
<img width="827" alt="Screenshot 2024-09-26 at 6 38 58 PM" src="https://github.com/user-attachments/assets/f13f0d9a-cc01-46f9-9b50-54ad46173d07">


After:
<img width="832" alt="Screenshot 2024-09-26 at 6 38 36 PM" src="https://github.com/user-attachments/assets/2353af84-1c2b-4a4d-839d-dffacfae4f5a">
